### PR TITLE
Refacting to current version of React (16.3.1)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+/*
+** Refactoring based on braking changes of 15.5 version of react
+** React.PropTypes has moved into a different package since React v15.5.
+** Please use the prop-types library instead.
+ */
+import PropTypes from 'prop-types';
 import {
   View,
   Modal,

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "eslint-plugin-react": "^6.1.2"
   },
   "dependencies": {
-    "react": "^15.3.0",
-    "react-native": "^0.32.0",
-    "react-native-maps": "^0.8.0"
+    "prop-types": "^15.6.1",
+    "react": "^16.3.1",
+    "react-native": "^0.55.3",
+    "react-native-maps": "^0.21.0"
   }
 }


### PR DESCRIPTION
Upgrade of React, React-native and React-native-maps versions, including some refactory to this code be suited with PropTypes new library, outside of react.