### PR TITLE
 Refacting to current version of React (16.3.1) and move from static PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,25 +16,7 @@ import MapView, { Marker } from 'react-native-maps';
 
 const { height, width } = Dimensions.get('window');
 
-export default class LocationPicker extends Component {
-  static propTypes = {
-    location: PropTypes.object,
-    onFinish: PropTypes.func.isRequired,
-    renderButton: PropTypes.func.isRequired,
-    renderInput: PropTypes.func.isRequired,
-    markerText: PropTypes.string,
-    markerView: PropTypes.node,
-    markerImage: PropTypes.number,
-    buttonContainerStyles: PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.number,
-    ]),
-    mapStyles: PropTypes.oneOfType([
-      PropTypes.object,
-      PropTypes.number,
-    ]),
-  };
-
+class LocationPicker extends Component {
   state = {
     coordinates: {
       latitude: 37.78825,
@@ -116,6 +98,26 @@ export default class LocationPicker extends Component {
     );
   }
 }
+
+LocationPicker.propTypes = {
+  location: PropTypes.object,
+  onFinish: PropTypes.func.isRequired,
+  renderButton: PropTypes.func.isRequired,
+  renderInput: PropTypes.func.isRequired,
+  markerText: PropTypes.string,
+  markerView: PropTypes.node,
+  markerImage: PropTypes.number,
+  buttonContainerStyles: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number,
+  ]),
+  mapStyles: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.number,
+  ]),
+}
+
+export default LocationPicker;
 
 const styles = StyleSheet.create({
   map: {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+/*
+** Refactoring based on braking changes of 15.5 version of react
+** React.PropTypes has moved into a different package since React v15.5.
+** Please use the prop-types library instead.
+ */
+import PropTypes from 'prop-types';
 import {
   View,
   Modal,

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "eslint-plugin-react": "^6.1.2"
   },
   "dependencies": {
-    "react": "^15.3.0",
-    "react-native": "^0.32.0",
-    "react-native-maps": "^0.8.0"
+    "prop-types": "^15.6.1",
+    "react": "^16.3.1",
+    "react-native": "^0.55.3",
+    "react-native-maps": "^0.21.0"
   }
 }


### PR DESCRIPTION
Adapt code to current version of React (16.3.1) and PropTypes library.